### PR TITLE
Avoid java.awt.HeadlessException in headless mode.

### DIFF
--- a/src/main/java/mcib_plugins/Ellipsoids_3D.java
+++ b/src/main/java/mcib_plugins/Ellipsoids_3D.java
@@ -195,7 +195,7 @@ public class Ellipsoids_3D implements PlugInFilter {
                 row++;
             }
         }
-        rt.show("Ellipsoid");
+        rt.show("Results");
 
         ImagePlus plus = new ImagePlus("Ellipsoids", ellipsoid.getStack());
         if (cal != null) {


### PR DESCRIPTION
Avoids the HeadlessException as discussed in #9.
